### PR TITLE
Bump to v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ by adding `smart_city_registry` to your list of dependencies in `mix.exs` as fol
 ```elixir
 def deps do
   [
-    {:smart_city_registry, "~> 2.4.0", organization: "smartcolumbus_os"}
+    {:smart_city_registry, "~> 2.5.0", organization: "smartcolumbus_os"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.Registry.MixProject do
   def project do
     [
       app: :smart_city_registry,
-      version: "2.4.0",
+      version: "2.5.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- `dn` support for org struct
- `Organization.write/1` can return an error tuple
- Update `smart_city` dependency