### PR TITLE
SMRT-1311 add protocol

### DIFF
--- a/lib/smart_city/dataset.ex
+++ b/lib/smart_city/dataset.ex
@@ -41,6 +41,7 @@ defmodule SmartCity.Dataset do
         }
       ],
       "sourceUrl": "",
+      "protocol": "", //defaults to nil. Can be HTTP1 or HTTP2
       "authUrl": "",
       "sourceFormat": "",
       "sourceType": "",     // remote|stream|batch

--- a/lib/smart_city/dataset/technical.ex
+++ b/lib/smart_city/dataset/technical.ex
@@ -22,6 +22,7 @@ defmodule SmartCity.Dataset.Technical do
           validations: not_required(list()),
           sourceHeaders: not_required(map()),
           authHeaders: not_required(map()),
+          protocol: not_required(String.t()),
           partitioner: not_required(%{type: String.t(), query: String.t()}),
           private: not_required(boolean())
         }
@@ -43,6 +44,7 @@ defmodule SmartCity.Dataset.Technical do
             sourceUrl: nil,
             authUrl: nil,
             systemName: nil,
+            protocol: nil,
             transformations: [],
             validations: []
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.Registry.MixProject do
   def project do
     [
       app: :smart_city_registry,
-      version: "3.0.0",
+      version: "3.1.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
co-authored-by: Paul Linville <plinville@pillartechnology.com>

Protocol will be used for downloading from servers that can't stream with HTTP2 etc.